### PR TITLE
Changed protobufjs from 6.11.2 to 6.11.3 to mitigate the prototype po…

### DIFF
--- a/src/currencyservice/package-lock.json
+++ b/src/currencyservice/package-lock.json
@@ -2095,7 +2095,7 @@
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
         "proto3-json-serializer": "^0.1.8",
-        "protobufjs": "6.11.2",
+        "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
       },
       "bin": {

--- a/src/paymentservice/package-lock.json
+++ b/src/paymentservice/package-lock.json
@@ -1990,7 +1990,7 @@
         "node-fetch": "^2.6.1",
         "object-hash": "^3.0.0",
         "proto3-json-serializer": "^0.1.8",
-        "protobufjs": "6.11.2",
+        "protobufjs": "6.11.3",
         "retry-request": "^4.0.0"
       },
       "bin": {


### PR DESCRIPTION
…llution issue

### Background 
Protobufjs was running an older code which was susceptible to Prototype Pollution.

### Fixes 
Changed version from 6.11.2 to 6.11.3. This kept the functionality of the application while also mitigating the issue.
